### PR TITLE
Fix ValueError in StructureFunction2DStack.calculate_modal_power

### DIFF
--- a/eddy/structurefunction.py
+++ b/eddy/structurefunction.py
@@ -2918,7 +2918,7 @@ class StructureFunction2DStack:
             * ``frac_of_data_total``: ``sum_m frac_of_data``, ``(N_ref,)``.
             * ``popt``, ``perr``: the raw fit outputs.
         """
-        popt, perr = self.fit_spiral(modes=modes, axis=axis, p0=p0)
+        popt, perr, _ = self.fit_spiral(modes=modes, axis=axis, p0=p0)
         offset = popt[:, 0]
         amps = popt[:, 1:]
         power = amps ** 2


### PR DESCRIPTION
## Summary
- `calculate_modal_power` called `fit_spiral` expecting a 2-tuple return, but `fit_spiral` returns 3 values, causing a `ValueError: too many values to unpack`.
- Unpack the third return value (discarded) so the call matches `fit_spiral`'s actual signature.

## Test plan
- [x] Existing test suite passes (`pytest tests/`)
